### PR TITLE
Enable github validation for pull-requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Continuous Integration
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  check-freeze-period:
+    if: github.event_name == 'pull_request'
+    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/verifyFreezePeriod.yml@master
+  check-merge-commits:
+    if: github.event_name == 'pull_request'
+    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/checkMergeCommits.yml@master
+  build:
+    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/mavenBuild.yml@master
+

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,15 @@
+name: Publish Unit Test Results
+
+on:
+  workflow_run:
+    workflows: ["Continuous Integration"]
+    types:
+      - completed
+
+jobs:
+    check:
+       uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/publishTestResults.yml@master
+
+
+
+


### PR DESCRIPTION
Currently there is no validation when open a PR for oomph code, this is quite bad as it introduce the risk that after mering the code do not build naymore or test fail without a contributor to get noticed about that.

This adds the platform unified workflow for building maven based projects.