### PR TITLE
Updated Epsilon's setup urls to point to GitHub

### DIFF
--- a/setups/org.eclipse.applications.setup
+++ b/setups/org.eclipse.applications.setup
@@ -20,7 +20,7 @@
   <product href="org.eclipse.platform.sdk.product.setup#/"/>
   <product href="http://git.eclipse.org/c/cdo/cdo.git/plain/plugins/org.eclipse.emf.cdo.server.product/CDOServer.setup#/"/>
   <product href="http://git.eclipse.org/c/cdo/cdo.git/plain/plugins/org.eclipse.emf.cdo.explorer.ui/CDOExplorer.setup#/"/>
-  <product href="https://git.eclipse.org/c/epsilon/org.eclipse.epsilon.git/plain/releng/org.eclipse.epsilon.releng/epsilonUse.setup#/"/>
+  <product href="https://raw.githubusercontent.com/eclipse/epsilon/main/releng/org.eclipse.epsilon.releng/epsilonUse.setup#/"/>
   <product href="interim/products/PapyrusWithCDO.setup#/"/>
   <description>The catalog of applications provided by projects at Eclipse.org.</description>
 </setup:ProductCatalog>

--- a/setups/org.eclipse.projects.setup
+++ b/setups/org.eclipse.projects.setup
@@ -1221,7 +1221,7 @@
   <project href="interim/EMFCompare.setup#/"/>
   <project href="https://raw.githubusercontent.com/eclipse-emf-parsley/emf-parsley/master/devtools/org.eclipse.emf.parsley.oomph/EMFParsley.setup#/"/>
   <project href="https://raw.githubusercontent.com/eclipse-packaging/packages/master/releng/org.eclipse.epp.config/oomph/EPP.setup#/"/>
-  <project href="https://git.eclipse.org/c/epsilon/org.eclipse.epsilon.git/plain/releng/org.eclipse.epsilon.releng/epsilonDev.setup#/"/>
+  <project href="https://raw.githubusercontent.com/eclipse/epsilon/main/releng/org.eclipse.epsilon.releng/epsilonDev.setup#/"/>
   <project href="https://raw.githubusercontent.com/eclipse-equinox/equinox/master/releng/org.eclipse.equinox.releng/Equinox.setup#/"/>
   <project href="interim/GEF.setup#/"/>
   <project href="interim/GMFNotation.setup#/"/>


### PR DESCRIPTION
Following Epsilon's move to GitHub, setup file URLs need to be updated accordingly.