### PR TITLE
Update EclEmma.setup URL

### DIFF
--- a/setups/org.eclipse.projects.setup
+++ b/setups/org.eclipse.projects.setup
@@ -1288,7 +1288,7 @@
   <project href="interim/E4Tools.setup#/"/>
   <project href="https://gitlab.eclipse.org/eclipse/ease/ease/-/raw/main/releng/org.eclipse.ease.releng/oomph/ease.setup#/"/>
   <project href="https://raw.githubusercontent.com/eclipse/ecf/master/releng/org.eclipse.ecf.releng/ECF.setup#/"/>
-  <project href="https://raw.githubusercontent.com/eclipse/eclemma/master/EclEmma.setup#/"/>
+  <project href="https://raw.githubusercontent.com/eclipse-eclemma/eclemma/master/EclEmma.setup#/"/>
   <project href="https://raw.githubusercontent.com/eclipse/elk/master/setups/EclipseLayoutKernel.setup#/"/>
   <project href="https://git.eclipse.org/c/ecoretools/org.eclipse.ecoretools.git/plain/org.eclipse.emf.ecoretools.build/EcoreTools.setup#/"/>
   <project href="https://git.eclipse.org/c/egit/egit.git/plain/tools/oomph/EGit.setup#/"/>


### PR DESCRIPTION
Eclipse EclEmma has been moved into its own GitHub organization - see https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/4074