### PR TITLE
Add DynamicMavenProjectFactory to deal with tycho-pomless

### DIFF
--- a/plugins/org.eclipse.oomph.resources/model/Resources.ecore
+++ b/plugins/org.eclipse.oomph.resources/model/Resources.ecore
@@ -74,4 +74,5 @@
       serializable="false"/>
   <eClassifiers xsi:type="ecore:EDataType" name="ProgressMonitor" instanceClassName="org.eclipse.core.runtime.IProgressMonitor"
       serializable="false"/>
+  <eClassifiers xsi:type="ecore:EClass" name="DynamicMavenProjectFactory" eSuperTypes="#//MavenProjectFactory"/>
 </ecore:EPackage>

--- a/plugins/org.eclipse.oomph.resources/model/Resources.genmodel
+++ b/plugins/org.eclipse.oomph.resources/model/Resources.genmodel
@@ -51,5 +51,6 @@
     <genClasses image="false" ecoreClass="Resources.ecore#//XMLProjectFactory"/>
     <genClasses ecoreClass="Resources.ecore#//EclipseProjectFactory"/>
     <genClasses ecoreClass="Resources.ecore#//MavenProjectFactory"/>
+    <genClasses ecoreClass="Resources.ecore#//DynamicMavenProjectFactory"/>
   </genPackages>
 </genmodel:GenModel>

--- a/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/DynamicMavenProjectFactory.java
+++ b/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/DynamicMavenProjectFactory.java
@@ -1,0 +1,22 @@
+/**
+ */
+package org.eclipse.oomph.resources;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the model object '<em><b>Dynamic Maven Project Factory</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ *
+ * @see org.eclipse.oomph.resources.ResourcesPackage#getDynamicMavenProjectFactory()
+ * @model
+ * @generated
+ */
+public interface DynamicMavenProjectFactory extends MavenProjectFactory
+{
+
+  String getXMLFileName();
+
+  void setXMLFileName(String xmlFileName);
+
+} // DynamicMavenProjectFactory

--- a/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/MavenProjectFactory.java
+++ b/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/MavenProjectFactory.java
@@ -25,6 +25,8 @@ import org.eclipse.emf.common.util.EList;
  */
 public interface MavenProjectFactory extends XMLProjectFactory
 {
-  public static final EList<ProjectFactory> LIST = ECollections.singletonEList((ProjectFactory)ResourcesFactory.eINSTANCE.createMavenProjectFactory());
+  public static final EList<ProjectFactory> LIST = ECollections.singletonEList(ResourcesFactory.eINSTANCE.createMavenProjectFactory());
+
+  public static final String POM_XML = "pom.xml"; //$NON-NLS-1$
 
 } // MavenProjectFactory

--- a/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/ResourcesFactory.java
+++ b/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/ResourcesFactory.java
@@ -57,6 +57,15 @@ public interface ResourcesFactory extends EFactory
    */
   MavenProjectFactory createMavenProjectFactory();
 
+  /**
+   * Returns a new object of class '<em>Dynamic Maven Project Factory</em>'.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @return a new object of class '<em>Dynamic Maven Project Factory</em>'.
+   * @generated
+   */
+  DynamicMavenProjectFactory createDynamicMavenProjectFactory();
+
   SourceLocator createSourceLocator(String rootFolder);
 
   SourceLocator createSourceLocator(String rootFolder, boolean locateNestedProjects);

--- a/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/ResourcesPackage.java
+++ b/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/ResourcesPackage.java
@@ -482,6 +482,79 @@ public interface ResourcesPackage extends EPackage
   int MAVEN_PROJECT_FACTORY_OPERATION_COUNT = XML_PROJECT_FACTORY_OPERATION_COUNT + 0;
 
   /**
+   * The meta object id for the '{@link org.eclipse.oomph.resources.impl.DynamicMavenProjectFactoryImpl <em>Dynamic Maven Project Factory</em>}' class.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @see org.eclipse.oomph.resources.impl.DynamicMavenProjectFactoryImpl
+   * @see org.eclipse.oomph.resources.impl.ResourcesPackageImpl#getDynamicMavenProjectFactory()
+   * @generated
+   */
+  int DYNAMIC_MAVEN_PROJECT_FACTORY = 5;
+
+  /**
+   * The feature id for the '<em><b>Annotations</b></em>' containment reference list.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int DYNAMIC_MAVEN_PROJECT_FACTORY__ANNOTATIONS = MAVEN_PROJECT_FACTORY__ANNOTATIONS;
+
+  /**
+   * The feature id for the '<em><b>Excluded Paths</b></em>' attribute list.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int DYNAMIC_MAVEN_PROJECT_FACTORY__EXCLUDED_PATHS = MAVEN_PROJECT_FACTORY__EXCLUDED_PATHS;
+
+  /**
+   * The number of structural features of the '<em>Dynamic Maven Project Factory</em>' class.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int DYNAMIC_MAVEN_PROJECT_FACTORY_FEATURE_COUNT = MAVEN_PROJECT_FACTORY_FEATURE_COUNT + 0;
+
+  /**
+   * The operation id for the '<em>Get Annotation</em>' operation.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int DYNAMIC_MAVEN_PROJECT_FACTORY___GET_ANNOTATION__STRING = MAVEN_PROJECT_FACTORY___GET_ANNOTATION__STRING;
+
+  /**
+   * The operation id for the '<em>Create Project</em>' operation.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int DYNAMIC_MAVEN_PROJECT_FACTORY___CREATE_PROJECT__BACKENDCONTAINER_BACKENDCONTAINER_IPROGRESSMONITOR = MAVEN_PROJECT_FACTORY___CREATE_PROJECT__BACKENDCONTAINER_BACKENDCONTAINER_IPROGRESSMONITOR;
+
+  /**
+   * The operation id for the '<em>Is Excluded Path</em>' operation.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int DYNAMIC_MAVEN_PROJECT_FACTORY___IS_EXCLUDED_PATH__BACKENDCONTAINER_BACKENDCONTAINER = MAVEN_PROJECT_FACTORY___IS_EXCLUDED_PATH__BACKENDCONTAINER_BACKENDCONTAINER;
+
+  /**
+   * The number of operations of the '<em>Dynamic Maven Project Factory</em>' class.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   * @ordered
+   */
+  int DYNAMIC_MAVEN_PROJECT_FACTORY_OPERATION_COUNT = MAVEN_PROJECT_FACTORY_OPERATION_COUNT + 0;
+
+  /**
    * The meta object id for the '<em>Project Handler</em>' data type.
    * <!-- begin-user-doc -->
    * <!-- end-user-doc -->
@@ -489,7 +562,7 @@ public interface ResourcesPackage extends EPackage
    * @see org.eclipse.oomph.resources.impl.ResourcesPackageImpl#getProjectHandler()
    * @generated
    */
-  int PROJECT_HANDLER = 5;
+  int PROJECT_HANDLER = 6;
 
   /**
    * The meta object id for the '<em>Backend Container</em>' data type.
@@ -499,7 +572,7 @@ public interface ResourcesPackage extends EPackage
    * @see org.eclipse.oomph.resources.impl.ResourcesPackageImpl#getBackendContainer()
    * @generated
    */
-  int BACKEND_CONTAINER = 6;
+  int BACKEND_CONTAINER = 7;
 
   /**
    * The meta object id for the '<em>Multi Status</em>' data type.
@@ -509,7 +582,7 @@ public interface ResourcesPackage extends EPackage
    * @see org.eclipse.oomph.resources.impl.ResourcesPackageImpl#getMultiStatus()
    * @generated
    */
-  int MULTI_STATUS = 7;
+  int MULTI_STATUS = 8;
 
   /**
    * The meta object id for the '<em>Progress Monitor</em>' data type.
@@ -519,7 +592,7 @@ public interface ResourcesPackage extends EPackage
    * @see org.eclipse.oomph.resources.impl.ResourcesPackageImpl#getProgressMonitor()
    * @generated
    */
-  int PROGRESS_MONITOR = 8;
+  int PROGRESS_MONITOR = 9;
 
   /**
    * Returns the meta object for class '{@link org.eclipse.oomph.resources.SourceLocator <em>Source Locator</em>}'.
@@ -686,6 +759,16 @@ public interface ResourcesPackage extends EPackage
    * @generated
    */
   EClass getMavenProjectFactory();
+
+  /**
+   * Returns the meta object for class '{@link org.eclipse.oomph.resources.DynamicMavenProjectFactory <em>Dynamic Maven Project Factory</em>}'.
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @return the meta object for class '<em>Dynamic Maven Project Factory</em>'.
+   * @see org.eclipse.oomph.resources.DynamicMavenProjectFactory
+   * @generated
+   */
+  EClass getDynamicMavenProjectFactory();
 
   /**
    * Returns the meta object for data type '{@link org.eclipse.oomph.resources.ProjectHandler <em>Project Handler</em>}'.
@@ -896,6 +979,16 @@ public interface ResourcesPackage extends EPackage
      * @generated
      */
     EClass MAVEN_PROJECT_FACTORY = eINSTANCE.getMavenProjectFactory();
+
+    /**
+     * The meta object literal for the '{@link org.eclipse.oomph.resources.impl.DynamicMavenProjectFactoryImpl <em>Dynamic Maven Project Factory</em>}' class.
+     * <!-- begin-user-doc -->
+     * <!-- end-user-doc -->
+     * @see org.eclipse.oomph.resources.impl.DynamicMavenProjectFactoryImpl
+     * @see org.eclipse.oomph.resources.impl.ResourcesPackageImpl#getDynamicMavenProjectFactory()
+     * @generated
+     */
+    EClass DYNAMIC_MAVEN_PROJECT_FACTORY = eINSTANCE.getDynamicMavenProjectFactory();
 
     /**
      * The meta object literal for the '<em>Project Handler</em>' data type.

--- a/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/impl/DynamicMavenProjectFactoryImpl.java
+++ b/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/impl/DynamicMavenProjectFactoryImpl.java
@@ -1,0 +1,57 @@
+/**
+ */
+package org.eclipse.oomph.resources.impl;
+
+import org.eclipse.oomph.resources.DynamicMavenProjectFactory;
+import org.eclipse.oomph.resources.ResourcesPackage;
+
+import org.eclipse.emf.ecore.EClass;
+
+import java.util.Objects;
+
+/**
+ * <!-- begin-user-doc -->
+ * An implementation of the model object '<em><b>Dynamic Maven Project Factory</b></em>'.
+ * <!-- end-user-doc -->
+ *
+ * @generated
+ */
+public class DynamicMavenProjectFactoryImpl extends MavenProjectFactoryImpl implements DynamicMavenProjectFactory
+{
+
+  private String xmlFileName;
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  protected DynamicMavenProjectFactoryImpl()
+  {
+    super();
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  @Override
+  protected EClass eStaticClass()
+  {
+    return ResourcesPackage.Literals.DYNAMIC_MAVEN_PROJECT_FACTORY;
+  }
+
+  @Override
+  public void setXMLFileName(String xmlFileName)
+  {
+    this.xmlFileName = xmlFileName;
+  }
+
+  @Override
+  public String getXMLFileName()
+  {
+    return Objects.requireNonNullElse(xmlFileName, super.getXMLFileName());
+  }
+
+} // DynamicMavenProjectFactoryImpl

--- a/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/impl/MavenProjectFactoryImpl.java
+++ b/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/impl/MavenProjectFactoryImpl.java
@@ -52,7 +52,7 @@ public class MavenProjectFactoryImpl extends XMLProjectFactoryImpl implements Ma
   @Override
   protected String getXMLFileName()
   {
-    return "pom.xml"; //$NON-NLS-1$
+    return POM_XML;
   }
 
   @Override

--- a/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/impl/ResourcesFactoryImpl.java
+++ b/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/impl/ResourcesFactoryImpl.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.oomph.resources.impl;
 
+import org.eclipse.oomph.resources.DynamicMavenProjectFactory;
 import org.eclipse.oomph.resources.EclipseProjectFactory;
 import org.eclipse.oomph.resources.MavenProjectFactory;
 import org.eclipse.oomph.resources.ResourcesFactory;
@@ -81,6 +82,8 @@ public class ResourcesFactoryImpl extends EFactoryImpl implements ResourcesFacto
         return createEclipseProjectFactory();
       case ResourcesPackage.MAVEN_PROJECT_FACTORY:
         return createMavenProjectFactory();
+      case ResourcesPackage.DYNAMIC_MAVEN_PROJECT_FACTORY:
+        return createDynamicMavenProjectFactory();
       default:
         throw new IllegalArgumentException("The class '" + eClass.getName() + "' is not a valid classifier"); //$NON-NLS-1$ //$NON-NLS-2$
     }
@@ -150,6 +153,18 @@ public class ResourcesFactoryImpl extends EFactoryImpl implements ResourcesFacto
   {
     MavenProjectFactoryImpl mavenProjectFactory = new MavenProjectFactoryImpl();
     return mavenProjectFactory;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  @Override
+  public DynamicMavenProjectFactory createDynamicMavenProjectFactory()
+  {
+    DynamicMavenProjectFactory dynamicMavenProjectFactory = new DynamicMavenProjectFactoryImpl();
+    return dynamicMavenProjectFactory;
   }
 
   @Override

--- a/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/impl/ResourcesPackageImpl.java
+++ b/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/impl/ResourcesPackageImpl.java
@@ -12,6 +12,7 @@ package org.eclipse.oomph.resources.impl;
 
 import org.eclipse.oomph.base.BasePackage;
 import org.eclipse.oomph.predicates.PredicatesPackage;
+import org.eclipse.oomph.resources.DynamicMavenProjectFactory;
 import org.eclipse.oomph.resources.EclipseProjectFactory;
 import org.eclipse.oomph.resources.MavenProjectFactory;
 import org.eclipse.oomph.resources.ProjectFactory;
@@ -75,6 +76,13 @@ public class ResourcesPackageImpl extends EPackageImpl implements ResourcesPacka
    * @generated
    */
   private EClass mavenProjectFactoryEClass = null;
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  private EClass dynamicMavenProjectFactoryEClass = null;
 
   /**
    * <!-- begin-user-doc -->
@@ -357,6 +365,17 @@ public class ResourcesPackageImpl extends EPackageImpl implements ResourcesPacka
    * @generated
    */
   @Override
+  public EClass getDynamicMavenProjectFactory()
+  {
+    return dynamicMavenProjectFactoryEClass;
+  }
+
+  /**
+   * <!-- begin-user-doc -->
+   * <!-- end-user-doc -->
+   * @generated
+   */
+  @Override
   public EDataType getProjectHandler()
   {
     return projectHandlerEDataType;
@@ -450,6 +469,8 @@ public class ResourcesPackageImpl extends EPackageImpl implements ResourcesPacka
 
     mavenProjectFactoryEClass = createEClass(MAVEN_PROJECT_FACTORY);
 
+    dynamicMavenProjectFactoryEClass = createEClass(DYNAMIC_MAVEN_PROJECT_FACTORY);
+
     // Create data types
     projectHandlerEDataType = createEDataType(PROJECT_HANDLER);
     backendContainerEDataType = createEDataType(BACKEND_CONTAINER);
@@ -499,6 +520,7 @@ public class ResourcesPackageImpl extends EPackageImpl implements ResourcesPacka
     xmlProjectFactoryEClass.getESuperTypes().add(getProjectFactory());
     eclipseProjectFactoryEClass.getESuperTypes().add(getXMLProjectFactory());
     mavenProjectFactoryEClass.getESuperTypes().add(getXMLProjectFactory());
+    dynamicMavenProjectFactoryEClass.getESuperTypes().add(getMavenProjectFactory());
 
     // Initialize classes, features, and operations; add parameters
     initEClass(sourceLocatorEClass, SourceLocator.class, "SourceLocator", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
@@ -549,6 +571,9 @@ public class ResourcesPackageImpl extends EPackageImpl implements ResourcesPacka
     initEClass(eclipseProjectFactoryEClass, EclipseProjectFactory.class, "EclipseProjectFactory", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
 
     initEClass(mavenProjectFactoryEClass, MavenProjectFactory.class, "MavenProjectFactory", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$
+
+    initEClass(dynamicMavenProjectFactoryEClass, DynamicMavenProjectFactory.class, "DynamicMavenProjectFactory", !IS_ABSTRACT, !IS_INTERFACE, //$NON-NLS-1$
+        IS_GENERATED_INSTANCE_CLASS);
 
     // Initialize data types
     initEDataType(projectHandlerEDataType, ProjectHandler.class, "ProjectHandler", !IS_SERIALIZABLE, !IS_GENERATED_INSTANCE_CLASS); //$NON-NLS-1$

--- a/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/util/ResourcesAdapterFactory.java
+++ b/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/util/ResourcesAdapterFactory.java
@@ -11,6 +11,7 @@
 package org.eclipse.oomph.resources.util;
 
 import org.eclipse.oomph.base.ModelElement;
+import org.eclipse.oomph.resources.DynamicMavenProjectFactory;
 import org.eclipse.oomph.resources.EclipseProjectFactory;
 import org.eclipse.oomph.resources.MavenProjectFactory;
 import org.eclipse.oomph.resources.ProjectFactory;
@@ -116,6 +117,12 @@ public class ResourcesAdapterFactory extends AdapterFactoryImpl
     }
 
     @Override
+    public Adapter caseDynamicMavenProjectFactory(DynamicMavenProjectFactory object)
+    {
+      return createDynamicMavenProjectFactoryAdapter();
+    }
+
+    @Override
     public Adapter caseModelElement(ModelElement object)
     {
       return createModelElementAdapter();
@@ -213,6 +220,21 @@ public class ResourcesAdapterFactory extends AdapterFactoryImpl
    * @generated
    */
   public Adapter createMavenProjectFactoryAdapter()
+  {
+    return null;
+  }
+
+  /**
+   * Creates a new adapter for an object of class '{@link org.eclipse.oomph.resources.DynamicMavenProjectFactory <em>Dynamic Maven Project Factory</em>}'.
+   * <!-- begin-user-doc -->
+   * This default implementation returns null so that we can easily ignore cases;
+   * it's useful to ignore a case when inheritance will catch all the cases anyway.
+   * <!-- end-user-doc -->
+   * @return the new adapter.
+   * @see org.eclipse.oomph.resources.DynamicMavenProjectFactory
+   * @generated
+   */
+  public Adapter createDynamicMavenProjectFactoryAdapter()
   {
     return null;
   }

--- a/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/util/ResourcesSwitch.java
+++ b/plugins/org.eclipse.oomph.resources/src/org/eclipse/oomph/resources/util/ResourcesSwitch.java
@@ -11,6 +11,7 @@
 package org.eclipse.oomph.resources.util;
 
 import org.eclipse.oomph.base.ModelElement;
+import org.eclipse.oomph.resources.DynamicMavenProjectFactory;
 import org.eclipse.oomph.resources.EclipseProjectFactory;
 import org.eclipse.oomph.resources.MavenProjectFactory;
 import org.eclipse.oomph.resources.ProjectFactory;
@@ -175,6 +176,32 @@ public class ResourcesSwitch<T> extends Switch<T>
         }
         return result;
       }
+      case ResourcesPackage.DYNAMIC_MAVEN_PROJECT_FACTORY:
+      {
+        DynamicMavenProjectFactory dynamicMavenProjectFactory = (DynamicMavenProjectFactory)theEObject;
+        T result = caseDynamicMavenProjectFactory(dynamicMavenProjectFactory);
+        if (result == null)
+        {
+          result = caseMavenProjectFactory(dynamicMavenProjectFactory);
+        }
+        if (result == null)
+        {
+          result = caseXMLProjectFactory(dynamicMavenProjectFactory);
+        }
+        if (result == null)
+        {
+          result = caseProjectFactory(dynamicMavenProjectFactory);
+        }
+        if (result == null)
+        {
+          result = caseModelElement(dynamicMavenProjectFactory);
+        }
+        if (result == null)
+        {
+          result = defaultCase(theEObject);
+        }
+        return result;
+      }
       default:
         return defaultCase(theEObject);
     }
@@ -256,6 +283,22 @@ public class ResourcesSwitch<T> extends Switch<T>
    * @generated
    */
   public T caseMavenProjectFactory(MavenProjectFactory object)
+  {
+    return null;
+  }
+
+  /**
+   * Returns the result of interpreting the object as an instance of '<em>Dynamic Maven Project Factory</em>'.
+   * <!-- begin-user-doc -->
+   * This implementation returns null;
+   * returning a non-null result will terminate the switch.
+   * <!-- end-user-doc -->
+   * @param object the target of the switch.
+   * @return the result of interpreting the object as an instance of '<em>Dynamic Maven Project Factory</em>'.
+   * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
+   * @generated
+   */
+  public T caseDynamicMavenProjectFactory(DynamicMavenProjectFactory object)
   {
     return null;
   }

--- a/setups/models/Resources.ecore
+++ b/setups/models/Resources.ecore
@@ -74,4 +74,5 @@
       serializable="false"/>
   <eClassifiers xsi:type="ecore:EDataType" name="ProgressMonitor" instanceClassName="org.eclipse.core.runtime.IProgressMonitor"
       serializable="false"/>
+  <eClassifiers xsi:type="ecore:EClass" name="DynamicMavenProjectFactory" eSuperTypes="#//MavenProjectFactory"/>
 </ecore:EPackage>


### PR DESCRIPTION
This is my attempt of solving #55. During the Maven import it checks if the pom.xml filename from m2e **isn't** `pom.xml` (it can be many things with Tycho). If so, it uses that as the `pom.xml` instead. Obviously tested with my local setup and it is able to import the projects.

This is my first time doing anything with the Oomph codebase, so apologies if I didn't do something right.