### PR TITLE
Update VIATRA setup url

### DIFF
--- a/setups/org.eclipse.projects.setup
+++ b/setups/org.eclipse.projects.setup
@@ -1360,7 +1360,7 @@
   <project href="https://raw.githubusercontent.com/eclipse-tycho/tycho/master/setup/Tycho.setup#/"/>
   <project href="https://raw.githubusercontent.com/eclipse-uml2/uml2/master/releng/org.eclipse.uml2.build-feature/UML2.setup#/"/>
   <project href="https://git.eclipse.org/c/usssdk/org.eclipse.usssdk.git/plain/org.eclipse.userstorage.releng/UserStorage.setup#/"/>
-  <project href="https://git.eclipse.org/c/viatra/org.eclipse.viatra.git/plain/releng/org.eclipse.viatra.setup/VIATRAEMF.setup#/"/>
+  <project href="https://raw.githubusercontent.com/eclipse-viatra/org.eclipse.viatra/master/releng/org.eclipse.viatra.setup/VIATRAEMF.setup#/"/>
   <project href="https://raw.githubusercontent.com/eclipse/windowbuilder/master/setups/WindowBuilder.setup#/"/>
   <project href="https://git.eclipse.org/c/webtools/webtools.releng.git/plain/installer/WTP.setup#/"/>
   <project href="https://git.eclipse.org/c/m2t/org.eclipse.xpand.git/plain/releng/org.eclipse.xpand.releng/Xpand.setup#/"/>


### PR DESCRIPTION
As VIATRA has moved its Git repository to Github, the Oomph setup URL needs to be updated.