### PR TITLE
Oomph Installer: Register eclipse+installer links for macOS

### DIFF
--- a/products/org.eclipse.oomph.setup.installer.product/Installer.product
+++ b/products/org.eclipse.oomph.setup.installer.product/Installer.product
@@ -31,7 +31,11 @@ Eclipse Installer
       location="org.eclipse.oomph.setup.installer" />
    <launcher name="eclipse-inst">
       <linux icon="icons/eclipse-inst.xpm"/>
-      <macosx icon="icons/eclipse-inst.icns"/>
+      <macosx icon="icons/eclipse-inst.icns">
+         <bundleUrlTypes>
+            <bundleUrlType scheme="eclipse+installer" name="Eclipse Installer"/>
+         </bundleUrlTypes>
+      </macosx>
       <win useIco="true">
          <ico path="icons/eclipse-inst.ico"/>
          <bmp/>


### PR DESCRIPTION
With https://github.com/eclipse-platform/eclipse.platform.ui/issues/1901 the auto-registration of link handlers was removed to avoid breaking of code signatures.

In order to use the 'eclipse+installer' URI scheme on macOS, this must instead be pre-registered during .app bundle build time before code signing.