### PR TITLE
Fix drag enter on macosX to set the event detail

### DIFF
--- a/plugins/org.eclipse.oomph.ui/src/org/eclipse/oomph/internal/ui/OomphDropAdapter.java
+++ b/plugins/org.eclipse.oomph.ui/src/org/eclipse/oomph/internal/ui/OomphDropAdapter.java
@@ -55,6 +55,12 @@ public class OomphDropAdapter extends EditingDomainViewerDropAdapter
     if (!HAS_EARLY_DRAG_SOURCE)
     {
       unavailableDelegates = null;
+
+      // On macos, event detail may be DROP_NONE
+      if (event.detail == DND.DROP_NONE)
+      {
+        event.detail = DND.DROP_COPY;
+      }
     }
     else
     {


### PR DESCRIPTION
Fixes https://github.com/eclipse-oomph/oomph/issues/111