### PR TITLE
Increase wait time to 5s for macos issue, not starting installed Eclipse

### DIFF
--- a/plugins/org.eclipse.oomph.util/src/org/eclipse/oomph/util/OS.java
+++ b/plugins/org.eclipse.oomph.util/src/org/eclipse/oomph/util/OS.java
@@ -197,7 +197,7 @@ public abstract class OS
     Process process = processBuilder.start();
     process.getInputStream().close();
     process.getOutputStream().close();
-    Thread.sleep(1000);
+    Thread.sleep(5000);
     process.getErrorStream().close();
     return process;
   }


### PR DESCRIPTION
I've started encountering https://github.com/eclipse-oomph/oomph/issues/52 again today on the latest Eclipse Installer.

I've gone through the process of changing the code and building a new repackaged installer with an increased timeout of 5s. It does just work now. Previously the eclipse installer was in a rush to shutdown, but now the result is, it finishes, waits around a bit, the splash of the newly installed Eclipse appears after a few seconds, then a few seconds later the Eclipse Installer shuts down.