### PR TITLE
Close inputStream before leaving method

### DIFF
--- a/plugins/org.eclipse.oomph.setup/src/org/eclipse/oomph/setup/impl/ResourceCreationTaskImpl.java
+++ b/plugins/org.eclipse.oomph.setup/src/org/eclipse/oomph/setup/impl/ResourceCreationTaskImpl.java
@@ -23,6 +23,7 @@ import org.eclipse.emf.ecore.xml.type.XMLTypeFactory;
 
 import org.eclipse.osgi.util.NLS;
 
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
@@ -419,7 +420,9 @@ public class ResourceCreationTaskImpl extends SetupTaskImpl implements ResourceC
       try
       {
         URIConverter uriConverter = context.getURIConverter();
-        byte[] bytes = uriConverter.createInputStream(targetURI).readAllBytes();
+        InputStream targetStream = uriConverter.createInputStream(targetURI);
+        byte[] bytes = targetStream.readAllBytes();
+        targetStream.close();
         String existingContent = "base64".equals(encoding) ? XMLTypeFactory.eINSTANCE.convertBase64Binary(bytes) : new String(bytes, encoding); //$NON-NLS-1$
         return !Objects.equals(content, existingContent);
       }


### PR DESCRIPTION
I've been experiencing a problem on Windows installs (only) when re-installing an IDE in the same location as the existing, checking the `Overwrite` box.

I would get an `java.io.IOException: Could not rename 'C:\Users\<usernmame>\CICS_IDz\idz17-galasa\eclipse\configuration' to 'C:\Users\<username>\CICS_IDz\idz17-galasa\eclipse\configuration.1737382787086'`, immediately on starting the install.

It whiffed of the `configuration` folder being locked for some reason, which is odd because at this point, nothing should have been written to the install location.

I debugged to find a few problems:

1. My resource creation tasks were falling over if `force` = `true`, because in all of my resource creation tasks, I hadn't set `Encoding` to any value. So there was NullPointerExceptions happening on [this line](https://github.com/eclipse-oomph/oomph/blob/d33905a0958ab4d952d352eb5ccff5b54844e430/plugins/org.eclipse.oomph.setup/src/org/eclipse/oomph/setup/impl/ResourceCreationTaskImpl.java#L423)
2. Because the exception was happening, it was being caught and dropping out without handling anything or raising any alarms.
3. After putting values into `Encoding`, I was still seeing the original error due to the `Configuration` folder being locked.

For whatever reason, on Windows, that input stream doesn't automatically close when exiting the function. So instead I've put in this fix to close the inputStream after all work has been done with it. This has now resolved the issue.



