### PR TITLE
Use compatible format for Windows distribution #156

### DIFF
--- a/products/org.eclipse.oomph.setup.installer.product/repackage-products.sh
+++ b/products/org.eclipse.oomph.setup.installer.product/repackage-products.sh
@@ -35,7 +35,7 @@ for i in $(ls); do
       mkdir -p tmp
       cd tmp
       unzip -qq ../$i
-      tar --format=gnu -cf ../${i%.zip}.tar *
+      tar --format=pax -cf ../${i%.zip}.tar *
       cd ..
       rm -rf tmp
       product=${i%.zip}.tar


### PR DESCRIPTION
Fixes #156.

MacOS's tar does not support old GNU format.

The change was tested on Windows. No warnings were printed on `tar -x`.
<img width="636" alt="Screenshot 2025-04-21 at 00 28 37" src="https://github.com/user-attachments/assets/3fef5f57-842e-4cd2-97ea-5dc94fb7b6ca" />
