### PR TITLE
Avoid NPE when getting resource from macro in ArgumentImpl #162

### DIFF
--- a/plugins/org.eclipse.oomph.setup/src/org/eclipse/oomph/setup/impl/ArgumentImpl.java
+++ b/plugins/org.eclipse.oomph.setup/src/org/eclipse/oomph/setup/impl/ArgumentImpl.java
@@ -207,16 +207,19 @@ public class ArgumentImpl extends ModelElementImpl implements Argument
             if (macroTask != null)
             {
               EObject resolvedMacro = resolveProxy((InternalEObject)macroTask.eGet(SetupPackage.Literals.MACRO_TASK__MACRO, false), demandLoad);
-              Resource eResource = resolvedMacro.eResource();
-              if (eResource instanceof Resource.Internal && !((Resource.Internal)eResource).isLoading() && resolvedMacro instanceof Macro)
+              if (resolvedMacro instanceof Macro)
               {
-                Macro macro = (Macro)resolvedMacro;
-                EList<Parameter> parameters = macro.getParameters();
-                for (Parameter parameter : parameters)
+                Resource eResource = resolvedMacro.eResource();
+                if (eResource instanceof Resource.Internal && !((Resource.Internal)eResource).isLoading())
                 {
-                  if (parameterName.equals(parameter.getName()))
+                  Macro macro = (Macro)resolvedMacro;
+                  EList<Parameter> parameters = macro.getParameters();
+                  for (Parameter parameter : parameters)
                   {
-                    return parameter;
+                    if (parameterName.equals(parameter.getName()))
+                    {
+                      return parameter;
+                    }
                   }
                 }
               }


### PR DESCRIPTION
Introduced by fdc1a4f6f526988ea34af359b39fa8dbc6dc9a95.

Changes:
- Split the `if` and change the order of checks
- Check for `instanceof Macro` first (includes null-check)
- Call `resolvedMacro.eResource();` inside top-level `if`
- Do the rest in second `if`